### PR TITLE
Display Player Gameplays

### DIFF
--- a/assets/elm/Main.elm
+++ b/assets/elm/Main.elm
@@ -25,7 +25,9 @@ main =
 
 
 type alias Model =
-    { gamesList : List Game
+    { displayPlayerGameplays : Bool
+    , gamesList : List Game
+    , gameplaysList : List Gameplay
     , playersList : List Player
     , errors : String
     }
@@ -41,6 +43,13 @@ type alias Game =
     }
 
 
+type alias Gameplay =
+    { gameId : Int
+    , playerId : Int
+    , playerScore : Int
+    }
+
+
 type alias Player =
     { displayName : Maybe String
     , id : Int
@@ -51,7 +60,9 @@ type alias Player =
 
 initialModel : Model
 initialModel =
-    { gamesList = []
+    { displayPlayerGameplays = False
+    , gamesList = []
+    , gameplaysList = []
     , playersList = []
     , errors = ""
     }
@@ -61,6 +72,7 @@ initialCommand : Cmd Msg
 initialCommand =
     Cmd.batch
         [ fetchGamesList
+        , fetchGameplaysList
         , fetchPlayersList
         ]
 
@@ -98,6 +110,27 @@ decodeGame =
         (Decode.field "title" Decode.string)
 
 
+fetchGameplaysList : Cmd Msg
+fetchGameplaysList =
+    Http.get "/api/gameplays" decodeGameplaysList
+        |> Http.send FetchGameplaysList
+
+
+decodeGameplaysList : Decode.Decoder (List Gameplay)
+decodeGameplaysList =
+    decodeGameplay
+        |> Decode.list
+        |> Decode.at [ "data" ]
+
+
+decodeGameplay : Decode.Decoder Gameplay
+decodeGameplay =
+    Decode.map3 Gameplay
+        (Decode.field "game_id" Decode.int)
+        (Decode.field "player_id" Decode.int)
+        (Decode.field "player_score" Decode.int)
+
+
 fetchPlayersList : Cmd Msg
 fetchPlayersList =
     Http.get "/api/players" decodePlayersList
@@ -125,17 +158,30 @@ decodePlayer =
 
 
 type Msg
-    = FetchGamesList (Result Http.Error (List Game))
+    = TogglePlayerGameplays
+    | FetchGamesList (Result Http.Error (List Game))
+    | FetchGameplaysList (Result Http.Error (List Gameplay))
     | FetchPlayersList (Result Http.Error (List Player))
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+        TogglePlayerGameplays ->
+            ( { model | displayPlayerGameplays = not model.displayPlayerGameplays }, Cmd.none )
+
         FetchGamesList result ->
             case result of
                 Ok games ->
                     ( { model | gamesList = games }, Cmd.none )
+
+                Err message ->
+                    ( { model | errors = toString message }, Cmd.none )
+
+        FetchGameplaysList result ->
+            case result of
+                Ok gameplays ->
+                    ( { model | gameplaysList = gameplays }, Cmd.none )
 
                 Err message ->
                     ( { model | errors = toString message }, Cmd.none )
@@ -230,15 +276,14 @@ gamesListItem game =
         ]
 
 
-playersIndex : Model -> Html msg
+playersIndex : Model -> Html Msg
 playersIndex model =
     if List.isEmpty model.playersList then
         div [] []
     else
         div [ class "players-index" ]
             [ h1 [ class "players-section" ] [ text "Players" ]
-            , playersList <|
-                playersSortedByScore model.playersList
+            , (playersList model) <| playersSortedByScore model.playersList
             ]
 
 
@@ -249,16 +294,16 @@ playersSortedByScore players =
         |> List.reverse
 
 
-playersList : List Player -> Html msg
-playersList players =
+playersList : Model -> List Player -> Html Msg
+playersList model players =
     div [ class "players-list panel panel-info" ]
         [ div [ class "panel-heading" ] [ text "Leaderboard" ]
-        , ul [ class "list-group" ] (List.map playersListItem players)
+        , ul [ class "list-group" ] (List.map (playersListItem model) players)
         ]
 
 
-playersListItem : Player -> Html msg
-playersListItem player =
+playersListItem : Model -> Player -> Html Msg
+playersListItem model player =
     let
         displayName =
             if player.displayName == Nothing then
@@ -270,6 +315,34 @@ playersListItem player =
             "players/" ++ (toString player.id)
     in
         li [ class "player-item list-group-item" ]
-            [ strong [] [ a [ href playerLink ] [ text displayName ] ]
+            [ strong [] [ a [ onClick TogglePlayerGameplays ] [ text displayName ] ]
             , span [ class "badge" ] [ text (toString player.score) ]
+            , if model.displayPlayerGameplays == True then
+                (playerGameplaysList model) player
+              else
+                div [] []
+            ]
+
+
+playerGameplaysList : Model -> Player -> Html msg
+playerGameplaysList model player =
+    let
+        gameplays =
+            List.filter (\gameplay -> gameplay.playerId == player.id) model.gameplaysList
+    in
+        ul [] (List.map (playerGameplaysListItem model) gameplays)
+
+
+playerGameplaysListItem : Model -> Gameplay -> Html msg
+playerGameplaysListItem model gameplay =
+    let
+        gameTitle =
+            if gameplay.gameId == 1 then
+                "Platformer   "
+            else
+                toString gameplay.gameId
+    in
+        li []
+            [ span [] [ text gameTitle ]
+            , span [ class "badge" ] [ text <| toString <| gameplay.playerScore ]
             ]

--- a/assets/elm/Platformer.elm
+++ b/assets/elm/Platformer.elm
@@ -118,7 +118,7 @@ initialSocket flags =
             else
                 "wss://elixir-elm-tutorial.herokuapp.com/socket/websocket?token=" ++ flags.token
     in
-        Phoenix.Socket.init prodSocketServer
+        Phoenix.Socket.init devSocketServer
             |> Phoenix.Socket.withDebug
             |> Phoenix.Socket.on "save_score" "score:platformer" SaveScore
             |> Phoenix.Socket.on "save_score" "score:platformer" ReceiveScoreChanges

--- a/assets/elm/Platformer.elm
+++ b/assets/elm/Platformer.elm
@@ -118,7 +118,7 @@ initialSocket flags =
             else
                 "wss://elixir-elm-tutorial.herokuapp.com/socket/websocket?token=" ++ flags.token
     in
-        Phoenix.Socket.init devSocketServer
+        Phoenix.Socket.init prodSocketServer
             |> Phoenix.Socket.withDebug
             |> Phoenix.Socket.on "save_score" "score:platformer" SaveScore
             |> Phoenix.Socket.on "save_score" "score:platformer" ReceiveScoreChanges

--- a/assets/js/elm.js
+++ b/assets/js/elm.js
@@ -15475,95 +15475,57 @@ var _fbonetti$elm_phoenix_socket$Phoenix_Socket$listen = F2(
 			});
 	});
 
-var _user$project$Main$playersListItem = function (player) {
-	var playerLink = A2(
-		_elm_lang$core$Basics_ops['++'],
-		'players/',
-		_elm_lang$core$Basics$toString(player.id));
-	var displayName = _elm_lang$core$Native_Utils.eq(player.displayName, _elm_lang$core$Maybe$Nothing) ? player.username : A2(_elm_lang$core$Maybe$withDefault, '', player.displayName);
-	return A2(
-		_elm_lang$html$Html$li,
-		{
-			ctor: '::',
-			_0: _elm_lang$html$Html_Attributes$class('player-item list-group-item'),
-			_1: {ctor: '[]'}
-		},
-		{
-			ctor: '::',
-			_0: A2(
-				_elm_lang$html$Html$strong,
-				{ctor: '[]'},
-				{
+var _user$project$Main$playerGameplaysListItem = F2(
+	function (model, gameplay) {
+		var gameTitle = _elm_lang$core$Native_Utils.eq(gameplay.gameId, 1) ? 'Platformer   ' : _elm_lang$core$Basics$toString(gameplay.gameId);
+		return A2(
+			_elm_lang$html$Html$li,
+			{ctor: '[]'},
+			{
+				ctor: '::',
+				_0: A2(
+					_elm_lang$html$Html$span,
+					{ctor: '[]'},
+					{
+						ctor: '::',
+						_0: _elm_lang$html$Html$text(gameTitle),
+						_1: {ctor: '[]'}
+					}),
+				_1: {
 					ctor: '::',
 					_0: A2(
-						_elm_lang$html$Html$a,
+						_elm_lang$html$Html$span,
 						{
 							ctor: '::',
-							_0: _elm_lang$html$Html_Attributes$href(playerLink),
+							_0: _elm_lang$html$Html_Attributes$class('badge'),
 							_1: {ctor: '[]'}
 						},
 						{
 							ctor: '::',
-							_0: _elm_lang$html$Html$text(displayName),
+							_0: _elm_lang$html$Html$text(
+								_elm_lang$core$Basics$toString(gameplay.playerScore)),
 							_1: {ctor: '[]'}
 						}),
 					_1: {ctor: '[]'}
-				}),
-			_1: {
-				ctor: '::',
-				_0: A2(
-					_elm_lang$html$Html$span,
-					{
-						ctor: '::',
-						_0: _elm_lang$html$Html_Attributes$class('badge'),
-						_1: {ctor: '[]'}
-					},
-					{
-						ctor: '::',
-						_0: _elm_lang$html$Html$text(
-							_elm_lang$core$Basics$toString(player.score)),
-						_1: {ctor: '[]'}
-					}),
-				_1: {ctor: '[]'}
-			}
-		});
-};
-var _user$project$Main$playersList = function (players) {
-	return A2(
-		_elm_lang$html$Html$div,
-		{
-			ctor: '::',
-			_0: _elm_lang$html$Html_Attributes$class('players-list panel panel-info'),
-			_1: {ctor: '[]'}
-		},
-		{
-			ctor: '::',
-			_0: A2(
-				_elm_lang$html$Html$div,
-				{
-					ctor: '::',
-					_0: _elm_lang$html$Html_Attributes$class('panel-heading'),
-					_1: {ctor: '[]'}
-				},
-				{
-					ctor: '::',
-					_0: _elm_lang$html$Html$text('Leaderboard'),
-					_1: {ctor: '[]'}
-				}),
-			_1: {
-				ctor: '::',
-				_0: A2(
-					_elm_lang$html$Html$ul,
-					{
-						ctor: '::',
-						_0: _elm_lang$html$Html_Attributes$class('list-group'),
-						_1: {ctor: '[]'}
-					},
-					A2(_elm_lang$core$List$map, _user$project$Main$playersListItem, players)),
-				_1: {ctor: '[]'}
-			}
-		});
-};
+				}
+			});
+	});
+var _user$project$Main$playerGameplaysList = F2(
+	function (model, player) {
+		var gameplays = A2(
+			_elm_lang$core$List$filter,
+			function (gameplay) {
+				return _elm_lang$core$Native_Utils.eq(gameplay.playerId, player.id);
+			},
+			model.gameplaysList);
+		return A2(
+			_elm_lang$html$Html$ul,
+			{ctor: '[]'},
+			A2(
+				_elm_lang$core$List$map,
+				_user$project$Main$playerGameplaysListItem(model),
+				gameplays));
+	});
 var _user$project$Main$playersSortedByScore = function (players) {
 	return _elm_lang$core$List$reverse(
 		A2(
@@ -15572,39 +15534,6 @@ var _user$project$Main$playersSortedByScore = function (players) {
 				return _.score;
 			},
 			players));
-};
-var _user$project$Main$playersIndex = function (model) {
-	return _elm_lang$core$List$isEmpty(model.playersList) ? A2(
-		_elm_lang$html$Html$div,
-		{ctor: '[]'},
-		{ctor: '[]'}) : A2(
-		_elm_lang$html$Html$div,
-		{
-			ctor: '::',
-			_0: _elm_lang$html$Html_Attributes$class('players-index'),
-			_1: {ctor: '[]'}
-		},
-		{
-			ctor: '::',
-			_0: A2(
-				_elm_lang$html$Html$h1,
-				{
-					ctor: '::',
-					_0: _elm_lang$html$Html_Attributes$class('players-section'),
-					_1: {ctor: '[]'}
-				},
-				{
-					ctor: '::',
-					_0: _elm_lang$html$Html$text('Players'),
-					_1: {ctor: '[]'}
-				}),
-			_1: {
-				ctor: '::',
-				_0: _user$project$Main$playersList(
-					_user$project$Main$playersSortedByScore(model.playersList)),
-				_1: {ctor: '[]'}
-			}
-		});
 };
 var _user$project$Main$gamesListItem = function (game) {
 	return A2(
@@ -15862,82 +15791,96 @@ var _user$project$Main$featured = function (model) {
 			{ctor: '[]'});
 	}
 };
-var _user$project$Main$view = function (model) {
-	return A2(
-		_elm_lang$html$Html$div,
-		{ctor: '[]'},
-		{
-			ctor: '::',
-			_0: _user$project$Main$featured(model),
-			_1: {
-				ctor: '::',
-				_0: _user$project$Main$gamesIndex(model),
-				_1: {
-					ctor: '::',
-					_0: _user$project$Main$playersIndex(model),
-					_1: {ctor: '[]'}
-				}
-			}
-		});
-};
 var _user$project$Main$subscriptions = function (model) {
 	return _elm_lang$core$Platform_Sub$none;
 };
 var _user$project$Main$update = F2(
 	function (msg, model) {
 		var _p2 = msg;
-		if (_p2.ctor === 'FetchGamesList') {
-			var _p3 = _p2._0;
-			if (_p3.ctor === 'Ok') {
+		switch (_p2.ctor) {
+			case 'TogglePlayerGameplays':
 				return {
 					ctor: '_Tuple2',
 					_0: _elm_lang$core$Native_Utils.update(
 						model,
-						{gamesList: _p3._0}),
+						{displayPlayerGameplays: !model.displayPlayerGameplays}),
 					_1: _elm_lang$core$Platform_Cmd$none
 				};
-			} else {
-				return {
-					ctor: '_Tuple2',
-					_0: _elm_lang$core$Native_Utils.update(
-						model,
-						{
-							errors: _elm_lang$core$Basics$toString(_p3._0)
-						}),
-					_1: _elm_lang$core$Platform_Cmd$none
-				};
-			}
-		} else {
-			var _p4 = _p2._0;
-			if (_p4.ctor === 'Ok') {
-				return {
-					ctor: '_Tuple2',
-					_0: _elm_lang$core$Native_Utils.update(
-						model,
-						{playersList: _p4._0}),
-					_1: _elm_lang$core$Platform_Cmd$none
-				};
-			} else {
-				return {
-					ctor: '_Tuple2',
-					_0: _elm_lang$core$Native_Utils.update(
-						model,
-						{
-							errors: _elm_lang$core$Basics$toString(_p4._0)
-						}),
-					_1: _elm_lang$core$Platform_Cmd$none
-				};
-			}
+			case 'FetchGamesList':
+				var _p3 = _p2._0;
+				if (_p3.ctor === 'Ok') {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{gamesList: _p3._0}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				} else {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{
+								errors: _elm_lang$core$Basics$toString(_p3._0)
+							}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				}
+			case 'FetchGameplaysList':
+				var _p4 = _p2._0;
+				if (_p4.ctor === 'Ok') {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{gameplaysList: _p4._0}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				} else {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{
+								errors: _elm_lang$core$Basics$toString(_p4._0)
+							}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				}
+			default:
+				var _p5 = _p2._0;
+				if (_p5.ctor === 'Ok') {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{playersList: _p5._0}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				} else {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{
+								errors: _elm_lang$core$Basics$toString(_p5._0)
+							}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				}
 		}
 	});
 var _user$project$Main$initialModel = {
+	displayPlayerGameplays: false,
 	gamesList: {ctor: '[]'},
+	gameplaysList: {ctor: '[]'},
 	playersList: {ctor: '[]'},
 	errors: ''
 };
-var _user$project$Main$Model = F3(
-	function (a, b, c) {
-		return {gamesList: a, playersList: b, errors: c};
+var _user$project$Main$Model = F5(
+	function (a, b, c, d, e) {
+		return {displayPlayerGameplays: a, gamesList: b, gameplaysList: c, playersList: d, errors: e};
 	});
 var _user$project$Main$Game = F6(
 	function (a, b, c, d, e, f) {
@@ -15960,6 +15903,24 @@ var _user$project$Main$decodeGamesList = A2(
 		_1: {ctor: '[]'}
 	},
 	_elm_lang$core$Json_Decode$list(_user$project$Main$decodeGame));
+var _user$project$Main$Gameplay = F3(
+	function (a, b, c) {
+		return {gameId: a, playerId: b, playerScore: c};
+	});
+var _user$project$Main$decodeGameplay = A4(
+	_elm_lang$core$Json_Decode$map3,
+	_user$project$Main$Gameplay,
+	A2(_elm_lang$core$Json_Decode$field, 'game_id', _elm_lang$core$Json_Decode$int),
+	A2(_elm_lang$core$Json_Decode$field, 'player_id', _elm_lang$core$Json_Decode$int),
+	A2(_elm_lang$core$Json_Decode$field, 'player_score', _elm_lang$core$Json_Decode$int));
+var _user$project$Main$decodeGameplaysList = A2(
+	_elm_lang$core$Json_Decode$at,
+	{
+		ctor: '::',
+		_0: 'data',
+		_1: {ctor: '[]'}
+	},
+	_elm_lang$core$Json_Decode$list(_user$project$Main$decodeGameplay));
 var _user$project$Main$Player = F4(
 	function (a, b, c, d) {
 		return {displayName: a, id: b, score: c, username: d};
@@ -15987,6 +15948,13 @@ var _user$project$Main$fetchPlayersList = A2(
 	_elm_lang$http$Http$send,
 	_user$project$Main$FetchPlayersList,
 	A2(_elm_lang$http$Http$get, '/api/players', _user$project$Main$decodePlayersList));
+var _user$project$Main$FetchGameplaysList = function (a) {
+	return {ctor: 'FetchGameplaysList', _0: a};
+};
+var _user$project$Main$fetchGameplaysList = A2(
+	_elm_lang$http$Http$send,
+	_user$project$Main$FetchGameplaysList,
+	A2(_elm_lang$http$Http$get, '/api/gameplays', _user$project$Main$decodeGameplaysList));
 var _user$project$Main$FetchGamesList = function (a) {
 	return {ctor: 'FetchGamesList', _0: a};
 };
@@ -16000,11 +15968,170 @@ var _user$project$Main$initialCommand = _elm_lang$core$Platform_Cmd$batch(
 		_0: _user$project$Main$fetchGamesList,
 		_1: {
 			ctor: '::',
-			_0: _user$project$Main$fetchPlayersList,
-			_1: {ctor: '[]'}
+			_0: _user$project$Main$fetchGameplaysList,
+			_1: {
+				ctor: '::',
+				_0: _user$project$Main$fetchPlayersList,
+				_1: {ctor: '[]'}
+			}
 		}
 	});
 var _user$project$Main$init = {ctor: '_Tuple2', _0: _user$project$Main$initialModel, _1: _user$project$Main$initialCommand};
+var _user$project$Main$TogglePlayerGameplays = {ctor: 'TogglePlayerGameplays'};
+var _user$project$Main$playersListItem = F2(
+	function (model, player) {
+		var playerLink = A2(
+			_elm_lang$core$Basics_ops['++'],
+			'players/',
+			_elm_lang$core$Basics$toString(player.id));
+		var displayName = _elm_lang$core$Native_Utils.eq(player.displayName, _elm_lang$core$Maybe$Nothing) ? player.username : A2(_elm_lang$core$Maybe$withDefault, '', player.displayName);
+		return A2(
+			_elm_lang$html$Html$li,
+			{
+				ctor: '::',
+				_0: _elm_lang$html$Html_Attributes$class('player-item list-group-item'),
+				_1: {ctor: '[]'}
+			},
+			{
+				ctor: '::',
+				_0: A2(
+					_elm_lang$html$Html$strong,
+					{ctor: '[]'},
+					{
+						ctor: '::',
+						_0: A2(
+							_elm_lang$html$Html$a,
+							{
+								ctor: '::',
+								_0: _elm_lang$html$Html_Events$onClick(_user$project$Main$TogglePlayerGameplays),
+								_1: {ctor: '[]'}
+							},
+							{
+								ctor: '::',
+								_0: _elm_lang$html$Html$text(displayName),
+								_1: {ctor: '[]'}
+							}),
+						_1: {ctor: '[]'}
+					}),
+				_1: {
+					ctor: '::',
+					_0: A2(
+						_elm_lang$html$Html$span,
+						{
+							ctor: '::',
+							_0: _elm_lang$html$Html_Attributes$class('badge'),
+							_1: {ctor: '[]'}
+						},
+						{
+							ctor: '::',
+							_0: _elm_lang$html$Html$text(
+								_elm_lang$core$Basics$toString(player.score)),
+							_1: {ctor: '[]'}
+						}),
+					_1: {
+						ctor: '::',
+						_0: _elm_lang$core$Native_Utils.eq(model.displayPlayerGameplays, true) ? A2(_user$project$Main$playerGameplaysList, model, player) : A2(
+							_elm_lang$html$Html$div,
+							{ctor: '[]'},
+							{ctor: '[]'}),
+						_1: {ctor: '[]'}
+					}
+				}
+			});
+	});
+var _user$project$Main$playersList = F2(
+	function (model, players) {
+		return A2(
+			_elm_lang$html$Html$div,
+			{
+				ctor: '::',
+				_0: _elm_lang$html$Html_Attributes$class('players-list panel panel-info'),
+				_1: {ctor: '[]'}
+			},
+			{
+				ctor: '::',
+				_0: A2(
+					_elm_lang$html$Html$div,
+					{
+						ctor: '::',
+						_0: _elm_lang$html$Html_Attributes$class('panel-heading'),
+						_1: {ctor: '[]'}
+					},
+					{
+						ctor: '::',
+						_0: _elm_lang$html$Html$text('Leaderboard'),
+						_1: {ctor: '[]'}
+					}),
+				_1: {
+					ctor: '::',
+					_0: A2(
+						_elm_lang$html$Html$ul,
+						{
+							ctor: '::',
+							_0: _elm_lang$html$Html_Attributes$class('list-group'),
+							_1: {ctor: '[]'}
+						},
+						A2(
+							_elm_lang$core$List$map,
+							_user$project$Main$playersListItem(model),
+							players)),
+					_1: {ctor: '[]'}
+				}
+			});
+	});
+var _user$project$Main$playersIndex = function (model) {
+	return _elm_lang$core$List$isEmpty(model.playersList) ? A2(
+		_elm_lang$html$Html$div,
+		{ctor: '[]'},
+		{ctor: '[]'}) : A2(
+		_elm_lang$html$Html$div,
+		{
+			ctor: '::',
+			_0: _elm_lang$html$Html_Attributes$class('players-index'),
+			_1: {ctor: '[]'}
+		},
+		{
+			ctor: '::',
+			_0: A2(
+				_elm_lang$html$Html$h1,
+				{
+					ctor: '::',
+					_0: _elm_lang$html$Html_Attributes$class('players-section'),
+					_1: {ctor: '[]'}
+				},
+				{
+					ctor: '::',
+					_0: _elm_lang$html$Html$text('Players'),
+					_1: {ctor: '[]'}
+				}),
+			_1: {
+				ctor: '::',
+				_0: A2(
+					_user$project$Main$playersList,
+					model,
+					_user$project$Main$playersSortedByScore(model.playersList)),
+				_1: {ctor: '[]'}
+			}
+		});
+};
+var _user$project$Main$view = function (model) {
+	return A2(
+		_elm_lang$html$Html$div,
+		{ctor: '[]'},
+		{
+			ctor: '::',
+			_0: _user$project$Main$featured(model),
+			_1: {
+				ctor: '::',
+				_0: _user$project$Main$gamesIndex(model),
+				_1: {
+					ctor: '::',
+					_0: _user$project$Main$playersIndex(model),
+					_1: {ctor: '[]'}
+				}
+			}
+		});
+};
 var _user$project$Main$main = _elm_lang$html$Html$program(
 	{init: _user$project$Main$init, view: _user$project$Main$view, update: _user$project$Main$update, subscriptions: _user$project$Main$subscriptions})();
 
@@ -16711,7 +16838,7 @@ var _user$project$Platformer$initialSocket = function (flags) {
 				'score:platformer',
 				_user$project$Platformer$SaveScore,
 				_fbonetti$elm_phoenix_socket$Phoenix_Socket$withDebug(
-					_fbonetti$elm_phoenix_socket$Phoenix_Socket$init(prodSocketServer)))));
+					_fbonetti$elm_phoenix_socket$Phoenix_Socket$init(devSocketServer)))));
 };
 var _user$project$Platformer$initialSocketJoin = function (flags) {
 	return _elm_lang$core$Tuple$first(
@@ -17008,7 +17135,7 @@ var _user$project$Platformer$NoOp = {ctor: 'NoOp'};
 var Elm = {};
 Elm['Main'] = Elm['Main'] || {};
 if (typeof _user$project$Main$main !== 'undefined') {
-    _user$project$Main$main(Elm['Main'], 'Main', {"types":{"unions":{"Dict.LeafColor":{"args":[],"tags":{"LBBlack":[],"LBlack":[]}},"Dict.Dict":{"args":["k","v"],"tags":{"RBNode_elm_builtin":["Dict.NColor","k","v","Dict.Dict k v","Dict.Dict k v"],"RBEmpty_elm_builtin":["Dict.LeafColor"]}},"Maybe.Maybe":{"args":["a"],"tags":{"Just":["a"],"Nothing":[]}},"Main.Msg":{"args":[],"tags":{"FetchGamesList":["Result.Result Http.Error (List Main.Game)"],"FetchPlayersList":["Result.Result Http.Error (List Main.Player)"]}},"Dict.NColor":{"args":[],"tags":{"BBlack":[],"Red":[],"NBlack":[],"Black":[]}},"Http.Error":{"args":[],"tags":{"BadUrl":["String"],"NetworkError":[],"Timeout":[],"BadStatus":["Http.Response String"],"BadPayload":["String","Http.Response String"]}},"Result.Result":{"args":["error","value"],"tags":{"Ok":["value"],"Err":["error"]}}},"aliases":{"Http.Response":{"args":["body"],"type":"{ url : String , status : { code : Int, message : String } , headers : Dict.Dict String String , body : body }"},"Main.Player":{"args":[],"type":"{ displayName : Maybe.Maybe String , id : Int , score : Int , username : String }"},"Main.Game":{"args":[],"type":"{ description : String , featured : Bool , id : Int , slug : String , thumbnail : String , title : String }"}},"message":"Main.Msg"},"versions":{"elm":"0.18.0"}});
+    _user$project$Main$main(Elm['Main'], 'Main', {"types":{"unions":{"Dict.LeafColor":{"args":[],"tags":{"LBBlack":[],"LBlack":[]}},"Dict.Dict":{"args":["k","v"],"tags":{"RBNode_elm_builtin":["Dict.NColor","k","v","Dict.Dict k v","Dict.Dict k v"],"RBEmpty_elm_builtin":["Dict.LeafColor"]}},"Maybe.Maybe":{"args":["a"],"tags":{"Just":["a"],"Nothing":[]}},"Main.Msg":{"args":[],"tags":{"FetchGameplaysList":["Result.Result Http.Error (List Main.Gameplay)"],"TogglePlayerGameplays":[],"FetchGamesList":["Result.Result Http.Error (List Main.Game)"],"FetchPlayersList":["Result.Result Http.Error (List Main.Player)"]}},"Dict.NColor":{"args":[],"tags":{"BBlack":[],"Red":[],"NBlack":[],"Black":[]}},"Http.Error":{"args":[],"tags":{"BadUrl":["String"],"NetworkError":[],"Timeout":[],"BadStatus":["Http.Response String"],"BadPayload":["String","Http.Response String"]}},"Result.Result":{"args":["error","value"],"tags":{"Ok":["value"],"Err":["error"]}}},"aliases":{"Http.Response":{"args":["body"],"type":"{ url : String , status : { code : Int, message : String } , headers : Dict.Dict String String , body : body }"},"Main.Player":{"args":[],"type":"{ displayName : Maybe.Maybe String , id : Int , score : Int , username : String }"},"Main.Gameplay":{"args":[],"type":"{ gameId : Int, playerId : Int, playerScore : Int }"},"Main.Game":{"args":[],"type":"{ description : String , featured : Bool , id : Int , slug : String , thumbnail : String , title : String }"}},"message":"Main.Msg"},"versions":{"elm":"0.18.0"}});
 }
 Elm['Platformer'] = Elm['Platformer'] || {};
 if (typeof _user$project$Platformer$main !== 'undefined') {

--- a/assets/js/elm.js
+++ b/assets/js/elm.js
@@ -15518,7 +15518,14 @@ var _user$project$Main$playerGameplaysList = F2(
 				return _elm_lang$core$Native_Utils.eq(gameplay.playerId, player.id);
 			},
 			model.gameplaysList);
-		return A2(
+		return _elm_lang$core$List$isEmpty(gameplays) ? A2(
+			_elm_lang$html$Html$p,
+			{ctor: '[]'},
+			{
+				ctor: '::',
+				_0: _elm_lang$html$Html$text('No gameplays to display yet!'),
+				_1: {ctor: '[]'}
+			}) : A2(
 			_elm_lang$html$Html$ul,
 			{ctor: '[]'},
 			A2(
@@ -15799,42 +15806,33 @@ var _user$project$Main$update = F2(
 		var _p2 = msg;
 		switch (_p2.ctor) {
 			case 'TogglePlayerGameplays':
+				var _p3 = _p2._0;
+				var newPlayersList = A2(
+					_elm_lang$core$List$map,
+					function (p) {
+						return _elm_lang$core$Native_Utils.eq(p.id, _p3.id) ? _elm_lang$core$Native_Utils.update(
+							_p3,
+							{
+								displayGameplays: _elm_lang$core$Maybe$Just(
+									!A2(_elm_lang$core$Maybe$withDefault, false, _p3.displayGameplays))
+							}) : p;
+					},
+					model.playersList);
 				return {
 					ctor: '_Tuple2',
 					_0: _elm_lang$core$Native_Utils.update(
 						model,
-						{displayPlayerGameplays: !model.displayPlayerGameplays}),
+						{playersList: newPlayersList}),
 					_1: _elm_lang$core$Platform_Cmd$none
 				};
 			case 'FetchGamesList':
-				var _p3 = _p2._0;
-				if (_p3.ctor === 'Ok') {
-					return {
-						ctor: '_Tuple2',
-						_0: _elm_lang$core$Native_Utils.update(
-							model,
-							{gamesList: _p3._0}),
-						_1: _elm_lang$core$Platform_Cmd$none
-					};
-				} else {
-					return {
-						ctor: '_Tuple2',
-						_0: _elm_lang$core$Native_Utils.update(
-							model,
-							{
-								errors: _elm_lang$core$Basics$toString(_p3._0)
-							}),
-						_1: _elm_lang$core$Platform_Cmd$none
-					};
-				}
-			case 'FetchGameplaysList':
 				var _p4 = _p2._0;
 				if (_p4.ctor === 'Ok') {
 					return {
 						ctor: '_Tuple2',
 						_0: _elm_lang$core$Native_Utils.update(
 							model,
-							{gameplaysList: _p4._0}),
+							{gamesList: _p4._0}),
 						_1: _elm_lang$core$Platform_Cmd$none
 					};
 				} else {
@@ -15848,14 +15846,14 @@ var _user$project$Main$update = F2(
 						_1: _elm_lang$core$Platform_Cmd$none
 					};
 				}
-			default:
+			case 'FetchGameplaysList':
 				var _p5 = _p2._0;
 				if (_p5.ctor === 'Ok') {
 					return {
 						ctor: '_Tuple2',
 						_0: _elm_lang$core$Native_Utils.update(
 							model,
-							{playersList: _p5._0}),
+							{gameplaysList: _p5._0}),
 						_1: _elm_lang$core$Platform_Cmd$none
 					};
 				} else {
@@ -15869,18 +15867,45 @@ var _user$project$Main$update = F2(
 						_1: _elm_lang$core$Platform_Cmd$none
 					};
 				}
+			default:
+				var _p6 = _p2._0;
+				if (_p6.ctor === 'Ok') {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{playersList: _p6._0}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				} else {
+					return {
+						ctor: '_Tuple2',
+						_0: _elm_lang$core$Native_Utils.update(
+							model,
+							{
+								errors: _elm_lang$core$Basics$toString(_p6._0)
+							}),
+						_1: _elm_lang$core$Platform_Cmd$none
+					};
+				}
 		}
 	});
+var _user$project$Main$anonymousPlayer = {
+	displayGameplays: _elm_lang$core$Maybe$Just(false),
+	displayName: _elm_lang$core$Maybe$Just('Anonymous User'),
+	id: 0,
+	score: 0,
+	username: 'anonymous'
+};
 var _user$project$Main$initialModel = {
-	displayPlayerGameplays: false,
 	gamesList: {ctor: '[]'},
 	gameplaysList: {ctor: '[]'},
 	playersList: {ctor: '[]'},
 	errors: ''
 };
-var _user$project$Main$Model = F5(
-	function (a, b, c, d, e) {
-		return {displayPlayerGameplays: a, gamesList: b, gameplaysList: c, playersList: d, errors: e};
+var _user$project$Main$Model = F4(
+	function (a, b, c, d) {
+		return {gamesList: a, gameplaysList: b, playersList: c, errors: d};
 	});
 var _user$project$Main$Game = F6(
 	function (a, b, c, d, e, f) {
@@ -15921,13 +15946,15 @@ var _user$project$Main$decodeGameplaysList = A2(
 		_1: {ctor: '[]'}
 	},
 	_elm_lang$core$Json_Decode$list(_user$project$Main$decodeGameplay));
-var _user$project$Main$Player = F4(
-	function (a, b, c, d) {
-		return {displayName: a, id: b, score: c, username: d};
+var _user$project$Main$Player = F5(
+	function (a, b, c, d, e) {
+		return {displayGameplays: a, displayName: b, id: c, score: d, username: e};
 	});
-var _user$project$Main$decodePlayer = A5(
-	_elm_lang$core$Json_Decode$map4,
+var _user$project$Main$decodePlayer = A6(
+	_elm_lang$core$Json_Decode$map5,
 	_user$project$Main$Player,
+	_elm_lang$core$Json_Decode$maybe(
+		A2(_elm_lang$core$Json_Decode$field, 'display_gameplays', _elm_lang$core$Json_Decode$bool)),
 	_elm_lang$core$Json_Decode$maybe(
 		A2(_elm_lang$core$Json_Decode$field, 'display_name', _elm_lang$core$Json_Decode$string)),
 	A2(_elm_lang$core$Json_Decode$field, 'id', _elm_lang$core$Json_Decode$int),
@@ -15977,13 +16004,17 @@ var _user$project$Main$initialCommand = _elm_lang$core$Platform_Cmd$batch(
 		}
 	});
 var _user$project$Main$init = {ctor: '_Tuple2', _0: _user$project$Main$initialModel, _1: _user$project$Main$initialCommand};
-var _user$project$Main$TogglePlayerGameplays = {ctor: 'TogglePlayerGameplays'};
+var _user$project$Main$TogglePlayerGameplays = function (a) {
+	return {ctor: 'TogglePlayerGameplays', _0: a};
+};
 var _user$project$Main$playersListItem = F2(
 	function (model, player) {
-		var playerLink = A2(
-			_elm_lang$core$Basics_ops['++'],
-			'players/',
-			_elm_lang$core$Basics$toString(player.id));
+		var displayGameplays = (_elm_lang$core$Native_Utils.eq(player.displayGameplays, _elm_lang$core$Maybe$Nothing) || _elm_lang$core$Native_Utils.eq(
+			player.displayGameplays,
+			_elm_lang$core$Maybe$Just(false))) ? A2(
+			_elm_lang$html$Html$div,
+			{ctor: '[]'},
+			{ctor: '[]'}) : A2(_user$project$Main$playerGameplaysList, model, player);
 		var displayName = _elm_lang$core$Native_Utils.eq(player.displayName, _elm_lang$core$Maybe$Nothing) ? player.username : A2(_elm_lang$core$Maybe$withDefault, '', player.displayName);
 		return A2(
 			_elm_lang$html$Html$li,
@@ -16003,7 +16034,8 @@ var _user$project$Main$playersListItem = F2(
 							_elm_lang$html$Html$a,
 							{
 								ctor: '::',
-								_0: _elm_lang$html$Html_Events$onClick(_user$project$Main$TogglePlayerGameplays),
+								_0: _elm_lang$html$Html_Events$onClick(
+									_user$project$Main$TogglePlayerGameplays(player)),
 								_1: {ctor: '[]'}
 							},
 							{
@@ -16030,10 +16062,7 @@ var _user$project$Main$playersListItem = F2(
 						}),
 					_1: {
 						ctor: '::',
-						_0: _elm_lang$core$Native_Utils.eq(model.displayPlayerGameplays, true) ? A2(_user$project$Main$playerGameplaysList, model, player) : A2(
-							_elm_lang$html$Html$div,
-							{ctor: '[]'},
-							{ctor: '[]'}),
+						_0: displayGameplays,
 						_1: {ctor: '[]'}
 					}
 				}
@@ -17135,7 +17164,7 @@ var _user$project$Platformer$NoOp = {ctor: 'NoOp'};
 var Elm = {};
 Elm['Main'] = Elm['Main'] || {};
 if (typeof _user$project$Main$main !== 'undefined') {
-    _user$project$Main$main(Elm['Main'], 'Main', {"types":{"unions":{"Dict.LeafColor":{"args":[],"tags":{"LBBlack":[],"LBlack":[]}},"Dict.Dict":{"args":["k","v"],"tags":{"RBNode_elm_builtin":["Dict.NColor","k","v","Dict.Dict k v","Dict.Dict k v"],"RBEmpty_elm_builtin":["Dict.LeafColor"]}},"Maybe.Maybe":{"args":["a"],"tags":{"Just":["a"],"Nothing":[]}},"Main.Msg":{"args":[],"tags":{"FetchGameplaysList":["Result.Result Http.Error (List Main.Gameplay)"],"TogglePlayerGameplays":[],"FetchGamesList":["Result.Result Http.Error (List Main.Game)"],"FetchPlayersList":["Result.Result Http.Error (List Main.Player)"]}},"Dict.NColor":{"args":[],"tags":{"BBlack":[],"Red":[],"NBlack":[],"Black":[]}},"Http.Error":{"args":[],"tags":{"BadUrl":["String"],"NetworkError":[],"Timeout":[],"BadStatus":["Http.Response String"],"BadPayload":["String","Http.Response String"]}},"Result.Result":{"args":["error","value"],"tags":{"Ok":["value"],"Err":["error"]}}},"aliases":{"Http.Response":{"args":["body"],"type":"{ url : String , status : { code : Int, message : String } , headers : Dict.Dict String String , body : body }"},"Main.Player":{"args":[],"type":"{ displayName : Maybe.Maybe String , id : Int , score : Int , username : String }"},"Main.Gameplay":{"args":[],"type":"{ gameId : Int, playerId : Int, playerScore : Int }"},"Main.Game":{"args":[],"type":"{ description : String , featured : Bool , id : Int , slug : String , thumbnail : String , title : String }"}},"message":"Main.Msg"},"versions":{"elm":"0.18.0"}});
+    _user$project$Main$main(Elm['Main'], 'Main', {"types":{"unions":{"Dict.LeafColor":{"args":[],"tags":{"LBBlack":[],"LBlack":[]}},"Dict.Dict":{"args":["k","v"],"tags":{"RBNode_elm_builtin":["Dict.NColor","k","v","Dict.Dict k v","Dict.Dict k v"],"RBEmpty_elm_builtin":["Dict.LeafColor"]}},"Maybe.Maybe":{"args":["a"],"tags":{"Just":["a"],"Nothing":[]}},"Main.Msg":{"args":[],"tags":{"FetchGameplaysList":["Result.Result Http.Error (List Main.Gameplay)"],"TogglePlayerGameplays":["Main.Player"],"FetchGamesList":["Result.Result Http.Error (List Main.Game)"],"FetchPlayersList":["Result.Result Http.Error (List Main.Player)"]}},"Dict.NColor":{"args":[],"tags":{"BBlack":[],"Red":[],"NBlack":[],"Black":[]}},"Http.Error":{"args":[],"tags":{"BadUrl":["String"],"NetworkError":[],"Timeout":[],"BadStatus":["Http.Response String"],"BadPayload":["String","Http.Response String"]}},"Result.Result":{"args":["error","value"],"tags":{"Ok":["value"],"Err":["error"]}}},"aliases":{"Http.Response":{"args":["body"],"type":"{ url : String , status : { code : Int, message : String } , headers : Dict.Dict String String , body : body }"},"Main.Player":{"args":[],"type":"{ displayGameplays : Maybe.Maybe Bool , displayName : Maybe.Maybe String , id : Int , score : Int , username : String }"},"Main.Gameplay":{"args":[],"type":"{ gameId : Int, playerId : Int, playerScore : Int }"},"Main.Game":{"args":[],"type":"{ description : String , featured : Bool , id : Int , slug : String , thumbnail : String , title : String }"}},"message":"Main.Msg"},"versions":{"elm":"0.18.0"}});
 }
 Elm['Platformer'] = Elm['Platformer'] || {};
 if (typeof _user$project$Platformer$main !== 'undefined') {

--- a/assets/js/elm.js
+++ b/assets/js/elm.js
@@ -16867,7 +16867,7 @@ var _user$project$Platformer$initialSocket = function (flags) {
 				'score:platformer',
 				_user$project$Platformer$SaveScore,
 				_fbonetti$elm_phoenix_socket$Phoenix_Socket$withDebug(
-					_fbonetti$elm_phoenix_socket$Phoenix_Socket$init(devSocketServer)))));
+					_fbonetti$elm_phoenix_socket$Phoenix_Socket$init(prodSocketServer)))));
 };
 var _user$project$Platformer$initialSocketJoin = function (flags) {
 	return _elm_lang$core$Tuple$first(


### PR DESCRIPTION
This PR fetches gameplays on the main Elm home page and allows them to be displayed for each player. Previously, there approach was to link to the Phoenix player show page and iterate through the collection there, but this allows us to not have to change "pages" and just display all player scores inline. The code could use some refactoring at some point, but it works well enough for now to get an idea of what the feature should look like in the next version of the book content.