### PR TITLE
Player Account Creation Routing

### DIFF
--- a/lib/platform_web/controllers/player_controller.ex
+++ b/lib/platform_web/controllers/player_controller.ex
@@ -22,7 +22,7 @@ defmodule PlatformWeb.PlayerController do
         conn
         |> PlatformWeb.PlayerAuthController.sign_in(player)
         |> put_flash(:info, "Player created successfully.")
-        |> redirect(to: player_path(conn, :show, player))
+        |> redirect(to: page_path(conn, :index))
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
     end

--- a/test/platform_web/controllers/player_controller_test.exs
+++ b/test/platform_web/controllers/player_controller_test.exs
@@ -29,12 +29,10 @@ defmodule PlatformWeb.PlayerControllerTest do
   describe "create player" do
     test "redirects to show when data is valid", %{conn: conn} do
       conn = post conn, player_path(conn, :create), player: @create_attrs
+      assert redirected_to(conn) == page_path(conn, :index)
 
-      assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == player_path(conn, :show, id)
-
-      conn = get conn, player_path(conn, :show, id)
-      assert html_response(conn, 200) =~ "Show Player"
+      conn = get conn, page_path(conn, :index)
+      assert html_response(conn, 200) =~ "Player created successfully"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
This isn't a big change, but it's huge in terms of usability. From
looking at FullStory, it was easy to see that players could get confused
when creating a new account and then just seeing their account
information on the player show page. There's not much to see there, and
clicking "Back" didn't seem intuitive.

This commit should allow players to go straight to the main Elm home
page and see a quick call to action with the "Play Now!" button.

Refs: #25